### PR TITLE
fix(security): enable Claude OAuth refresh and tighten sandbox access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ target/
 # MSVC Windows builds of rustc generate these, which store debugging information
 *.pdb
 actionlint
+worktrees/

--- a/profiles/base.toml
+++ b/profiles/base.toml
@@ -5,6 +5,7 @@ network_mode = "offline"
 
 [filesystem]
 allow_read = [
+    # System paths
     "/usr",
     "/bin",
     "/sbin",
@@ -21,8 +22,16 @@ allow_read = [
     "/var/run",
     "/tmp",
     "/dev",
+    # sx config
     "~/.config/sx",
-    "~/Library",
+    # ~/Library - allowlist only safe subdirectories (shift-left)
+    "~/Library/Caches/",
+    "~/Library/Preferences/",
+    "~/Library/Application Support/",
+    "~/Library/Logs/",
+    "~/Library/Frameworks/",
+    "~/Library/Keychains/", # Encrypted, requires Security framework ACL to access secrets
+    "~/Library/Developer/",
     # Shell config files (read-only)
     "~/.zshrc",
     "~/.zshenv",
@@ -32,6 +41,7 @@ allow_read = [
     "~/.profile",
     "~/.inputrc",
 ]
+# This enforce deny on critical path containing sensibles data even if user allow HOME directory in global config
 deny_read = [
     "~/.ssh",
     "~/.aws",
@@ -42,10 +52,8 @@ deny_read = [
 ]
 allow_write = [
     "/tmp",
-    "/private/var/folders",
-    "/private/var/run",
-    "/var/folders",
-    "/var/run"
+    "/private$TMPDIR", # Session-specific temp dir (canonical path)
+    "$TMPDIR", # Session-specific temp dir (symlink path)
 ]
 
 [shell]

--- a/profiles/claude.toml
+++ b/profiles/claude.toml
@@ -6,6 +6,7 @@ network_mode = "online"
 allow_read = [
     "~/.claude",
     "~/.claude.json",
+    "~/.claude.lock",
     "~/.local/share/claude",
     "~/.local/bin/claude",
     "~/.CFUserTextEncoding",
@@ -15,7 +16,10 @@ allow_read = [
 allow_write = [
     "~/.claude",
     "~/.claude.json",
+    "~/.claude.lock",
+    "~/.local/share/claude",
     "~/Library/Caches/claude-cli-nodejs/",
+    "~/Library/Keychains/login.keychain-db", # OAuth token refresh
     "/private/tmp/claude*", # claude-UID directories (e.g. claude-501)
     "/private/tmp/zsh*", # When claude use zsh in bash it create dynamic tmp file
 ]


### PR DESCRIPTION
## Summary
- Fixes OAuth token refresh failure when running Claude Code in sandbox (401 authentication_error)
- Enforces shift-left security principle by replacing broad `~/Library` read with allowlist of safe subdirectories
- Reduces attack surface by restricting write access to session-specific temp directory instead of all `/var/folders`

## Details
**Root cause:** Claude stores OAuth tokens in macOS Keychain (`~/Library/Keychains/login.keychain-db`). The sandbox allowed *reading* but not *writing* to the keychain, blocking token refresh after ~24 hours.

**Changes:**
1. **OAuth Fix:** Added write access to `~/Library/Keychains/login.keychain-db` (token refresh)
2. **Read Security:** Replaced `~/Library` (ALL data) with:
   - `~/Library/Caches/` ✓
   - `~/Library/Preferences/` ✓
   - `~/Library/Application Support/` ✓
   - `~/Library/Logs/` ✓
   - `~/Library/Frameworks/` ✓
   - `~/Library/Keychains/` ✓ (encrypted, requires Security framework ACL)
   - `~/Library/Developer/` ✓
   
   Now protected: Cookies, Mail, Messages, Safari, Calendar, Contacts, Accounts

3. **Write Security:** Restricted to session-specific temp:
   - Before: `/private/var/folders`, `/var/folders` (ALL apps' temp)
   - After: `$TMPDIR` (session-only)

## Test plan
- [x] Run `sx claude -- claude /login` and verify token refresh works
- [x] Run `sx -- mktemp` to verify temp file creation still works
- [x] All existing tests pass (`cargo test`)