### PR TITLE
docs(changelog): improve git-cliff config with version headers and dependency grouping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.0] - 2026-02-02
 
 ### Bug Fixes
 
@@ -13,6 +14,11 @@ All notable changes to this project will be documented in this file.
 - Bump the github-actions group with 3 updates (#15)
 
 
+### Dependencies
+
+- Bump clap from 4.5.54 to 4.5.56 in the rust-dependencies group (#14)
+
+
 ### Documentation
 
 - Rewrite for clarity and supply chain focus (#18)
@@ -22,18 +28,13 @@ All notable changes to this project will be documented in this file.
 
 - Add allow_list_dirs for Bun runtime compatibility (#17)
 
-
-### Deps
-
-- Bump clap from 4.5.54 to 4.5.56 in the rust-dependencies group (#14)
-
-
+## [0.2.9] - 2026-01-31
 
 ### Bug Fixes
 
 - **profile:** Allow Claude Code UID-suffixed tmp dirs and skills (#12)
 
-
+## [0.2.8] - 2026-01-30
 
 ### Bug Fixes
 
@@ -44,25 +45,25 @@ All notable changes to this project will be documented in this file.
 
 - Update installation to recommend Homebrew over Cargo
 
-
+## [0.2.7] - 2026-01-29
 
 ### Bug Fixes
 
 - **ci:** Simplify homebrew formula update, remove version line
 
-
+## [0.2.6] - 2026-01-29
 
 ### Bug Fixes
 
 - **ci:** Update homebrew script for binary formula
 
-
+## [0.2.5] - 2026-01-29
 
 ### Bug Fixes
 
 - **ci:** Replace mislav action with custom homebrew update script
 
-
+## [0.2.4] - 2026-01-29
 
 ### Bug Fixes
 
@@ -72,7 +73,7 @@ All notable changes to this project will be documented in this file.
 
 - **ci:** Add GITLEAKS_LICENSE secret to gitleaks action
 
-
+## [0.2.3] - 2026-01-29
 
 ### Bug Fixes
 
@@ -80,7 +81,7 @@ All notable changes to this project will be documented in this file.
 
 - **ci:** Use GitHub App token for release commits
 
-
+## [0.2.2] - 2026-01-28
 
 ### Bug Fixes
 
@@ -92,6 +93,5 @@ All notable changes to this project will be documented in this file.
 ### Refactor
 
 - **release:** Simplify Homebrew tap update workflow (#8)
-
 
 

--- a/cliff.toml
+++ b/cliff.toml
@@ -9,13 +9,18 @@ All notable changes to this project will be documented in this file.
 
 """
 body = """
+{% if version %}\
+    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else %}\
+    ## [Unreleased]
+{% endif %}\
 {% for group, commits in commits | group_by(attribute="group") %}
     ### {{ group | striptags | trim | upper_first }}
     {% for commit in commits %}
         - {% if commit.scope %}**{{ commit.scope }}:** {% endif %}\
             {{ commit.message | upper_first }}
     {% endfor %}
-{% endfor %}\n
+{% endfor %}
 """
 footer = """
 """
@@ -36,8 +41,9 @@ commit_parsers = [
     { message = "^test", group = "Testing" },
     { message = "^build", group = "Build" },
     { message = "^ci", group = "CI" },
+    { message = "^deps", group = "Dependencies" },
     { message = "^chore\\(release\\)", skip = true },
-    { message = "^chore\\(deps\\)", skip = true },
+    { message = "^chore\\(deps\\)", group = "Dependencies" },
     { message = "^chore", group = "Miscellaneous" },
 ]
 protect_breaking_commits = false


### PR DESCRIPTION
## Summary
- Fixed git-cliff template to add version headers and dates (e.g., `## [0.3.0] - 2026-02-02`)
- Consolidated duplicate section headers per version instead of repeating across all releases
- Added dependency commit grouping under "Dependencies" section instead of skipping them

## Test plan
- [x] Regenerated changelog with updated config - sections now properly grouped per version
- [x] Verified CI/CD will use updated config on next release without additional changes