### PR TITLE
fix(claude): add XDG state and cache paths for Claude Code 2.x

### DIFF
--- a/profiles/claude.toml
+++ b/profiles/claude.toml
@@ -8,6 +8,8 @@ allow_read = [
     "~/.claude.json",
     "~/.claude.lock",
     "~/.local/share/claude",
+    "~/.local/state/claude", # XDG state dir for locks
+    "~/.cache/claude",       # XDG cache dir for staging
     "~/.local/bin/claude",
     "~/.CFUserTextEncoding",
     "/private/tmp/claude*", # claude-UID directories (e.g. claude-501)
@@ -18,6 +20,8 @@ allow_write = [
     "~/.claude.json",
     "~/.claude.lock",
     "~/.local/share/claude",
+    "~/.local/state/claude", # XDG state dir for locks
+    "~/.cache/claude",       # XDG cache dir for staging
     "~/Library/Caches/claude-cli-nodejs/",
     "~/Library/Keychains/login.keychain-db", # OAuth token refresh
     "/private/tmp/claude*", # claude-UID directories (e.g. claude-501)


### PR DESCRIPTION
## Summary
- Add `~/.local/state/claude` to allow_read and allow_write for lock files
- Add `~/.cache/claude` to allow_read and allow_write for staging

## Problem
Claude Code 2.x uses XDG-style directories:
- `~/.local/state/claude/locks/` for lock files  
- `~/.cache/claude/staging/` for staging

The existing profile only allowed `~/.local/share/claude`, causing OAuth token refresh to fail when the lock file write was denied.

## Test plan
- [x] Run `sx claude` and verify OAuth refresh works without 401 errors
- [x] Verify lock files can be created in `~/.local/state/claude/locks/`
- [x] Verify staging works in `~/.cache/claude/staging/`