### PR TITLE
fix(security): harden sandbox with env filtering, mach/signal/dev restrictions

### DIFF
--- a/profiles/base.toml
+++ b/profiles/base.toml
@@ -21,7 +21,6 @@ allow_read = [
     "/var/folders",
     "/var/run",
     "/tmp",
-    "/dev",
     # sx config
     "~/.config/sx",
     # ~/Library - allowlist only safe subdirectories (shift-left)
@@ -59,6 +58,8 @@ allow_write = [
 [shell]
 pass_env = [
     "TERM",
+    "TERMINFO",
+    "TERMINFO_DIRS",
     "COLORTERM",
     "LANG",
     "LC_ALL",

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -189,7 +189,7 @@ fn build_sandbox_context(args: &Args) -> Result<SandboxContext> {
     let profile_names = collect_profile_names(args, &config, &working_dir);
 
     // Load and compose profiles
-    let profiles = load_profiles(&profile_names, None);
+    let profiles = load_profiles(&profile_names, None)?;
     let composed = compose_profiles(&profiles);
 
     // Build sandbox params with all overrides applied

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -9,8 +9,8 @@ use std::path::{Path, PathBuf};
 use super::args::Args;
 use crate::config::project::{load_project_config, PROJECT_CONFIG_NAME};
 use crate::config::{
-    compose_profiles, load_global_config, load_profiles, merge_configs, Config, ExecSugid,
-    NetworkMode, Profile,
+    compose_profiles, load_global_config, load_profiles, merge_configs, merge_unique, Config,
+    ExecSugid, NetworkMode, Profile,
 };
 use crate::detection::project_type::detect_project_types;
 use crate::sandbox::executor::execute_sandboxed_with_trace;
@@ -46,7 +46,6 @@ pub fn explain(args: &Args) -> Result<()> {
 
     // Exec sugid
     match &context.params.allow_exec_sugid {
-        ExecSugid::Allow(true) => println!("Setuid/Setgid Execution: ALLOW ALL"),
         ExecSugid::Paths(paths) if !paths.is_empty() => {
             println!("Setuid/Setgid Execution: specific binaries");
             for path in paths {
@@ -331,6 +330,15 @@ fn build_sandbox_params(
     // Build raw rules if present
     let raw_rules = profile.seatbelt.as_ref().and_then(|s| s.raw.clone());
 
+    // Collect shell env config from profile and config
+    let mut pass_env = config.shell.pass_env.clone();
+    merge_unique(&mut pass_env, &profile.shell.pass_env);
+
+    let mut deny_env = config.shell.deny_env.clone();
+    merge_unique(&mut deny_env, &profile.shell.deny_env);
+
+    let set_env = config.shell.set_env.clone();
+
     SandboxParams {
         working_dir,
         home_dir,
@@ -341,6 +349,9 @@ fn build_sandbox_params(
         allow_list_dirs: allow_list_dirs.into_iter().map(PathBuf::from).collect(),
         raw_rules,
         allow_exec_sugid,
+        pass_env,
+        deny_env,
+        set_env,
     }
 }
 

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -3,6 +3,7 @@
 //! Wires together config loading, profile composition, and sandbox execution.
 
 use anyhow::{Context, Result};
+use std::collections::HashSet;
 use std::env;
 use std::path::{Path, PathBuf};
 
@@ -295,10 +296,24 @@ fn build_sandbox_params(
     let mut deny_read = collect_deny_read_paths(config, profile, &args.deny_read);
     let mut allow_write = collect_allow_write_paths(config, profile, &args.allow_write);
     let mut allow_list_dirs = collect_allow_list_dirs_paths(config, profile);
+    let has_configured_list_dirs = !allow_list_dirs.is_empty();
+
+    if args.command.is_none() {
+        let shell_path = config
+            .sandbox
+            .shell
+            .clone()
+            .or_else(|| std::env::var("SHELL").ok())
+            .unwrap_or_else(|| "/bin/zsh".to_string());
+        let path_env = std::env::var("PATH").ok();
+        let shell_list_dirs =
+            collect_interactive_shell_list_dirs(&home_dir, &shell_path, path_env.as_deref());
+        merge_unique(&mut allow_list_dirs, &shell_list_dirs);
+    }
 
     // If allow_list_dirs is configured, add all parent directories of working_dir
     // This is needed for runtimes like Bun that scan ALL parent directories
-    if !allow_list_dirs.is_empty() {
+    if has_configured_list_dirs {
         let mut parent = working_dir.parent();
         while let Some(p) = parent {
             let path_str = p.to_string_lossy().to_string();
@@ -425,6 +440,37 @@ fn collect_allow_list_dirs_paths(config: &Config, profile: &Profile) -> Vec<Stri
     paths
 }
 
+fn collect_interactive_shell_list_dirs(
+    home_dir: &Path,
+    shell_path: &str,
+    path_env: Option<&str>,
+) -> Vec<String> {
+    let mut dirs = Vec::new();
+
+    if let Some(path_env) = path_env {
+        for entry in std::env::split_paths(path_env) {
+            if !entry.as_os_str().is_empty() {
+                dirs.push(entry.to_string_lossy().to_string());
+            }
+        }
+    }
+
+    if shell_path.ends_with("zsh") {
+        dirs.push(home_dir.join(".config/zsh").to_string_lossy().to_string());
+        dirs.push(
+            home_dir
+                .join(".config/zsh/completions")
+                .to_string_lossy()
+                .to_string(),
+        );
+    }
+
+    let mut seen = HashSet::new();
+    dirs.into_iter()
+        .filter(|dir| seen.insert(dir.clone()))
+        .collect()
+}
+
 /// Generate the default .sandbox.toml template
 fn generate_config_template() -> &'static str {
     r#"# .sandbox.toml
@@ -530,5 +576,33 @@ mod tests {
 
         let mode = determine_network_mode(&args, &profile, &config);
         assert_eq!(mode, NetworkMode::Localhost);
+    }
+
+    #[test]
+    fn test_collect_interactive_shell_list_dirs_adds_path_entries() {
+        let home_dir = Path::new("/Users/testuser");
+        let dirs = collect_interactive_shell_list_dirs(
+            home_dir,
+            "/bin/bash",
+            Some("/usr/local/bin:/opt/homebrew/bin:/usr/local/bin"),
+        );
+
+        assert!(dirs.contains(&"/usr/local/bin".to_string()));
+        assert!(dirs.contains(&"/opt/homebrew/bin".to_string()));
+        assert_eq!(
+            dirs.iter()
+                .filter(|d| d.as_str() == "/usr/local/bin")
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn test_collect_interactive_shell_list_dirs_adds_zsh_dirs() {
+        let home_dir = Path::new("/Users/testuser");
+        let dirs = collect_interactive_shell_list_dirs(home_dir, "/bin/zsh", Some("/usr/bin"));
+
+        assert!(dirs.contains(&"/Users/testuser/.config/zsh".to_string()));
+        assert!(dirs.contains(&"/Users/testuser/.config/zsh/completions".to_string()));
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -10,5 +10,6 @@ pub use profile::{
     compose_profiles, load_profile, load_profiles, BuiltinProfile, Profile, ProfileError,
     ProfileFilesystem, ProfileShell,
 };
+pub(crate) use profile::merge_unique;
 pub use project::load_project_config;
 pub use schema::{Config, ExecSugid, NetworkMode};

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -6,10 +6,10 @@ pub mod schema;
 
 pub use global::load_global_config;
 pub use merge::merge_configs;
+pub(crate) use profile::merge_unique;
 pub use profile::{
     compose_profiles, load_profile, load_profiles, BuiltinProfile, Profile, ProfileError,
     ProfileFilesystem, ProfileShell,
 };
-pub(crate) use profile::merge_unique;
 pub use project::load_project_config;
 pub use schema::{Config, ExecSugid, NetworkMode};

--- a/src/config/profile.rs
+++ b/src/config/profile.rs
@@ -229,21 +229,12 @@ pub fn load_profiles(names: &[String], custom_dir: Option<&Path>) -> Vec<Profile
                 }
             }
 
-            // Profile not found - warn and fallback to online
+            // Profile not found - error and skip (fail-closed)
             eprintln!(
-                "\x1b[33m[sx:warn]\x1b[0m Unknown profile '{}', falling back to 'online'",
+                "\x1b[31m[sx:error]\x1b[0m Unknown profile '{}', skipping (no fallback)",
                 name
             );
-            match BuiltinProfile::Online.load() {
-                Ok(profile) => Some(profile),
-                Err(e) => {
-                    eprintln!(
-                        "\x1b[31m[sx:error]\x1b[0m Failed to load fallback 'online' profile: {}",
-                        e
-                    );
-                    None
-                }
-            }
+            None
         })
         .collect()
 }
@@ -319,12 +310,48 @@ pub fn compose_profiles(profiles: &[Profile]) -> Profile {
 
 /// Merge unique strings from source into target.
 /// Uses HashSet for O(1) lookups instead of O(n) contains() checks.
-fn merge_unique(target: &mut Vec<String>, source: &[String]) {
+pub(crate) fn merge_unique(target: &mut Vec<String>, source: &[String]) {
     // Build set of existing items (owned strings to avoid borrow conflicts)
     let existing: HashSet<String> = target.iter().cloned().collect();
     for item in source {
         if !existing.contains(item) {
             target.push(item.clone());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_unknown_profile_returns_none() {
+        let profiles = load_profiles(&["nonexistent_profile".to_string()], None);
+        assert!(
+            profiles.is_empty(),
+            "Unknown profile should not load any profile"
+        );
+    }
+
+    #[test]
+    fn test_known_builtin_profiles_load() {
+        for name in &[
+            "base",
+            "online",
+            "localhost",
+            "rust",
+            "claude",
+            "gpg",
+            "bun",
+            "opencode",
+        ] {
+            let profiles = load_profiles(&[name.to_string()], None);
+            assert_eq!(
+                profiles.len(),
+                1,
+                "Builtin profile '{}' should load successfully",
+                name
+            );
         }
     }
 }

--- a/src/config/profile.rs
+++ b/src/config/profile.rs
@@ -15,6 +15,8 @@ pub enum ProfileError {
         name: &'static str,
         error: toml::de::Error,
     },
+    /// Profile name not found in any search location
+    NotFound { name: String },
 }
 
 impl std::fmt::Display for ProfileError {
@@ -25,6 +27,7 @@ impl std::fmt::Display for ProfileError {
             ProfileError::InvalidBuiltin { name, error } => {
                 write!(f, "Built-in profile '{}' is invalid: {}", name, error)
             }
+            ProfileError::NotFound { name } => write!(f, "Unknown profile '{}'", name),
         }
     }
 }
@@ -35,6 +38,7 @@ impl std::error::Error for ProfileError {
             ProfileError::Io(e) => Some(e),
             ProfileError::Parse(e) => Some(e),
             ProfileError::InvalidBuiltin { error, .. } => Some(error),
+            ProfileError::NotFound { .. } => None,
         }
     }
 }
@@ -168,42 +172,24 @@ pub fn load_profile(path: &Path) -> Result<Profile, ProfileError> {
 }
 
 /// Load profiles by name, optionally searching in a custom directory.
-/// Logs warnings for profiles that fail to load instead of silently skipping them.
-pub fn load_profiles(names: &[String], custom_dir: Option<&Path>) -> Vec<Profile> {
+/// Returns an error if any profile cannot be found or loaded.
+pub fn load_profiles(
+    names: &[String],
+    custom_dir: Option<&Path>,
+) -> Result<Vec<Profile>, ProfileError> {
     names
         .iter()
-        .filter_map(|name| {
+        .map(|name| {
             // First try builtin profiles
             if let Some(builtin) = BuiltinProfile::from_name(name) {
-                match builtin.load() {
-                    Ok(profile) => return Some(profile),
-                    Err(e) => {
-                        // This should never happen with properly tested builtin profiles
-                        eprintln!(
-                            "\x1b[31m[sx:error]\x1b[0m Failed to load builtin profile '{}': {}",
-                            name, e
-                        );
-                        return None;
-                    }
-                }
+                return builtin.load();
             }
 
             // Then try custom directory
             if let Some(dir) = custom_dir {
                 let path = dir.join(format!("{}.toml", name));
                 if path.exists() {
-                    match load_profile(&path) {
-                        Ok(profile) => return Some(profile),
-                        Err(e) => {
-                            eprintln!(
-                                "\x1b[33m[sx:warn]\x1b[0m Failed to load profile '{}' from {}: {}",
-                                name,
-                                path.display(),
-                                e
-                            );
-                            return None;
-                        }
-                    }
+                    return load_profile(&path);
                 }
             }
 
@@ -214,27 +200,11 @@ pub fn load_profiles(names: &[String], custom_dir: Option<&Path>) -> Vec<Profile
                     .join(".config/sx/profiles")
                     .join(format!("{}.toml", name));
                 if path.exists() {
-                    match load_profile(&path) {
-                        Ok(profile) => return Some(profile),
-                        Err(e) => {
-                            eprintln!(
-                                "\x1b[33m[sx:warn]\x1b[0m Failed to load profile '{}' from {}: {}",
-                                name,
-                                path.display(),
-                                e
-                            );
-                            return None;
-                        }
-                    }
+                    return load_profile(&path);
                 }
             }
 
-            // Profile not found - error and skip (fail-closed)
-            eprintln!(
-                "\x1b[31m[sx:error]\x1b[0m Unknown profile '{}', skipping (no fallback)",
-                name
-            );
-            None
+            Err(ProfileError::NotFound { name: name.clone() })
         })
         .collect()
 }
@@ -325,11 +295,11 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_unknown_profile_returns_none() {
-        let profiles = load_profiles(&["nonexistent_profile".to_string()], None);
+    fn test_unknown_profile_returns_error() {
+        let result = load_profiles(&["nonexistent_profile".to_string()], None);
         assert!(
-            profiles.is_empty(),
-            "Unknown profile should not load any profile"
+            matches!(result, Err(ProfileError::NotFound { .. })),
+            "Unknown profile should return NotFound error"
         );
     }
 
@@ -345,7 +315,7 @@ mod tests {
             "bun",
             "opencode",
         ] {
-            let profiles = load_profiles(&[name.to_string()], None);
+            let profiles = load_profiles(&[name.to_string()], None).unwrap();
             assert_eq!(
                 profiles.len(),
                 1,

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -8,22 +8,21 @@ use std::collections::HashMap;
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum ExecSugid {
-    /// Allow all (`true`) or deny all (`false`)
-    Allow(bool),
+    /// Deny all (`false`) - the only boolean value accepted
+    Deny(bool),
     /// Allow only specific binary paths
     Paths(Vec<String>),
 }
 
 impl Default for ExecSugid {
     fn default() -> Self {
-        ExecSugid::Allow(false)
+        ExecSugid::Deny(false)
     }
 }
 
 impl ExecSugid {
-    /// Returns true if this is the default deny-all policy
     pub fn is_default(&self) -> bool {
-        matches!(self, ExecSugid::Allow(false))
+        matches!(self, ExecSugid::Deny(false))
     }
 }
 
@@ -140,14 +139,14 @@ mod tests {
 
     #[test]
     fn test_exec_sugid_default_is_deny() {
-        assert_eq!(ExecSugid::default(), ExecSugid::Allow(false));
+        assert_eq!(ExecSugid::default(), ExecSugid::Deny(false));
         assert!(ExecSugid::default().is_default());
     }
 
     #[test]
     fn test_exec_sugid_is_default() {
-        assert!(ExecSugid::Allow(false).is_default());
-        assert!(!ExecSugid::Allow(true).is_default());
+        assert!(ExecSugid::Deny(false).is_default());
+        assert!(!ExecSugid::Deny(true).is_default());
         assert!(!ExecSugid::Paths(vec!["/bin/ps".into()]).is_default());
     }
 
@@ -163,12 +162,13 @@ mod tests {
 
     #[test]
     fn test_exec_sugid_deserialize_false() {
-        assert_eq!(parse_exec_sugid("value = false"), ExecSugid::Allow(false));
+        assert_eq!(parse_exec_sugid("value = false"), ExecSugid::Deny(false));
     }
 
     #[test]
-    fn test_exec_sugid_deserialize_true() {
-        assert_eq!(parse_exec_sugid("value = true"), ExecSugid::Allow(true));
+    fn test_exec_sugid_deserialize_true_is_safe() {
+        // Old configs with `true` silently degrade to Deny(true) which is safe
+        assert_eq!(parse_exec_sugid("value = true"), ExecSugid::Deny(true));
     }
 
     #[test]
@@ -188,19 +188,7 @@ allow_exec_sugid = false
 "#,
         )
         .unwrap();
-        assert_eq!(config.sandbox.allow_exec_sugid, ExecSugid::Allow(false));
-    }
-
-    #[test]
-    fn test_sandbox_config_with_exec_sugid_true() {
-        let config: Config = toml::from_str(
-            r#"
-[sandbox]
-allow_exec_sugid = true
-"#,
-        )
-        .unwrap();
-        assert_eq!(config.sandbox.allow_exec_sugid, ExecSugid::Allow(true));
+        assert_eq!(config.sandbox.allow_exec_sugid, ExecSugid::Deny(false));
     }
 
     #[test]

--- a/src/sandbox/executor.rs
+++ b/src/sandbox/executor.rs
@@ -109,6 +109,9 @@ pub fn execute_sandboxed_with_trace(
     let mut cmd = Command::new("/usr/bin/sandbox-exec");
     cmd.arg("-f").arg(profile_file.path());
 
+    // Apply environment filtering (clears env, then selectively passes through)
+    apply_env_filter(&mut cmd, params);
+
     // Set SANDBOX_MODE environment variable for shell prompt integration
     let mode_str = match params.network_mode {
         crate::config::schema::NetworkMode::Offline => "offline",
@@ -198,6 +201,10 @@ pub fn execute_sandboxed_captured(
     // Build sandbox-exec command
     let mut cmd = Command::new("/usr/bin/sandbox-exec");
     cmd.arg("-f").arg(profile_file.path());
+
+    // Apply environment filtering
+    apply_env_filter(&mut cmd, params);
+
     cmd.args(command);
 
     let output = cmd.output()?;
@@ -208,6 +215,81 @@ pub fn execute_sandboxed_captured(
 /// Print the generated seatbelt profile (dry-run mode)
 pub fn dry_run(params: &SandboxParams) -> Result<String, SeatbeltError> {
     generate_seatbelt_profile(params)
+}
+
+/// Check if an environment variable name matches any glob-like pattern.
+/// Supports `*` wildcards: `AWS_*` matches `AWS_SECRET_KEY`, `*_SECRET*` matches `MY_SECRET_VALUE`.
+fn matches_env_pattern(name: &str, patterns: &[String]) -> bool {
+    for pattern in patterns {
+        if pattern == name {
+            return true;
+        }
+        if pattern.contains('*') {
+            let parts: Vec<&str> = pattern.split('*').collect();
+            let mut pos = 0;
+            let mut matched = true;
+            for (i, part) in parts.iter().enumerate() {
+                if part.is_empty() {
+                    continue;
+                }
+                if i == 0 {
+                    if !name.starts_with(part) {
+                        matched = false;
+                        break;
+                    }
+                    pos = part.len();
+                } else if let Some(found) = name[pos..].find(part) {
+                    pos += found + part.len();
+                } else {
+                    matched = false;
+                    break;
+                }
+            }
+            if matched && !pattern.ends_with('*') {
+                if let Some(last) = parts.last() {
+                    if !last.is_empty() && !name.ends_with(last) {
+                        matched = false;
+                    }
+                }
+            }
+            if matched {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Apply environment filtering to a Command.
+/// Clears all env, then selectively passes through allowed vars.
+fn apply_env_filter(cmd: &mut Command, params: &SandboxParams) {
+    const DANGEROUS_PREFIXES: &[&str] = &["DYLD_"];
+
+    cmd.env_clear();
+
+    let parent_env: std::collections::HashMap<String, String> = std::env::vars().collect();
+
+    for (key, value) in &parent_env {
+        if DANGEROUS_PREFIXES.iter().any(|p| key.starts_with(p)) {
+            continue;
+        }
+        if matches_env_pattern(key, &params.deny_env) {
+            continue;
+        }
+        if params.pass_env.is_empty() || matches_env_pattern(key, &params.pass_env) {
+            cmd.env(key, value);
+        }
+    }
+
+    for (key, value) in &params.set_env {
+        if DANGEROUS_PREFIXES.iter().any(|p| key.starts_with(p)) {
+            continue;
+        }
+        if matches_env_pattern(key, &params.deny_env) {
+            continue;
+        }
+        cmd.env(key, value);
+    }
 }
 
 #[cfg(test)]
@@ -239,5 +321,49 @@ mod tests {
 
         let result = dry_run(&params);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_matches_env_pattern_exact() {
+        assert!(matches_env_pattern("HOME", &["HOME".to_string()]));
+        assert!(!matches_env_pattern("HOME", &["PATH".to_string()]));
+    }
+
+    #[test]
+    fn test_matches_env_pattern_prefix_wildcard() {
+        assert!(matches_env_pattern(
+            "AWS_SECRET_KEY",
+            &["AWS_*".to_string()]
+        ));
+        assert!(!matches_env_pattern("HOME", &["AWS_*".to_string()]));
+    }
+
+    #[test]
+    fn test_matches_env_pattern_contains_wildcard() {
+        assert!(matches_env_pattern(
+            "MY_SECRET_VALUE",
+            &["*_SECRET*".to_string()]
+        ));
+        assert!(!matches_env_pattern(
+            "MY_VALUE",
+            &["*_SECRET*".to_string()]
+        ));
+    }
+
+    #[test]
+    fn test_matches_env_pattern_suffix_wildcard() {
+        assert!(matches_env_pattern("GITHUB_KEY", &["*_KEY".to_string()]));
+        assert!(!matches_env_pattern(
+            "GITHUB_KEY_EXTRA",
+            &["*_KEY".to_string()]
+        ));
+    }
+
+    #[test]
+    fn test_matches_env_pattern_dyld_always_dangerous() {
+        assert!(matches_env_pattern(
+            "DYLD_INSERT_LIBRARIES",
+            &["DYLD_*".to_string()]
+        ));
     }
 }

--- a/src/sandbox/executor.rs
+++ b/src/sandbox/executor.rs
@@ -344,10 +344,7 @@ mod tests {
             "MY_SECRET_VALUE",
             &["*_SECRET*".to_string()]
         ));
-        assert!(!matches_env_pattern(
-            "MY_VALUE",
-            &["*_SECRET*".to_string()]
-        ));
+        assert!(!matches_env_pattern("MY_VALUE", &["*_SECRET*".to_string()]));
     }
 
     #[test]

--- a/src/sandbox/seatbelt.rs
+++ b/src/sandbox/seatbelt.rs
@@ -253,12 +253,15 @@ pub fn generate_seatbelt_profile(params: &SandboxParams) -> Result<String, Seatb
 
     // Device access - restricted to specific devices needed for shell/terminal operation
     profile.push_str("; Device access\n");
+    profile.push_str("(allow file-read-data (literal \"/dev\"))\n");
+    profile.push_str("(allow file-read-data (literal \"/dev/fd\"))\n");
     profile.push_str("(allow file-read* (literal \"/dev/null\"))\n");
     profile.push_str("(allow file-read* (literal \"/dev/zero\"))\n");
     profile.push_str("(allow file-read* (literal \"/dev/random\"))\n");
     profile.push_str("(allow file-read* (literal \"/dev/urandom\"))\n");
     profile.push_str("(allow file-read* (literal \"/dev/tty\"))\n");
     profile.push_str("(allow file-read* (literal \"/dev/ptmx\"))\n");
+    profile.push_str("(allow file-read* (regex #\"^/dev/fd/[0-9]+$\"))\n");
     profile.push_str("(allow file-read* (regex #\"^/dev/ttys[0-9]+$\"))\n");
     profile.push_str("(allow file-read* (literal \"/dev/dtracehelper\"))\n");
     profile.push_str("(allow file-read* (literal \"/dev/autofs_nowait\"))\n");
@@ -269,6 +272,7 @@ pub fn generate_seatbelt_profile(params: &SandboxParams) -> Result<String, Seatb
     profile.push_str("(allow file-write* (literal \"/dev/zero\"))\n");
     profile.push_str("(allow file-write* (literal \"/dev/tty\"))\n");
     profile.push_str("(allow file-write* (literal \"/dev/ptmx\"))\n");
+    profile.push_str("(allow file-write* (regex #\"^/dev/fd/[0-9]+$\"))\n");
     profile.push_str("(allow file-write* (regex #\"^/dev/ttys[0-9]+$\"))\n");
     profile.push_str("(allow file-write* (literal \"/dev/dtracehelper\"))\n");
     profile.push_str("(allow file-write* (literal \"/dev/stdout\"))\n");
@@ -608,14 +612,18 @@ mod tests {
             !profile.contains("(allow file-read* (subpath \"/dev\"))"),
             "Should not allow reads from all of /dev"
         );
+        assert!(profile.contains("(allow file-read-data (literal \"/dev\"))"));
+        assert!(profile.contains("(allow file-read-data (literal \"/dev/fd\"))"));
         assert!(profile.contains("(allow file-write* (literal \"/dev/null\"))"));
         assert!(profile.contains("(allow file-write* (literal \"/dev/tty\"))"));
         assert!(profile.contains("(allow file-read* (literal \"/dev/urandom\"))"));
         assert!(profile.contains("(allow file-read* (literal \"/dev/stdin\"))"));
         assert!(profile.contains("(allow file-read* (literal \"/dev/stdout\"))"));
         assert!(profile.contains("(allow file-read* (literal \"/dev/stderr\"))"));
+        assert!(profile.contains("(allow file-read* (regex #\"^/dev/fd/[0-9]+$\"))"));
         assert!(profile.contains("(allow file-write* (literal \"/dev/stdout\"))"));
         assert!(profile.contains("(allow file-write* (literal \"/dev/stderr\"))"));
+        assert!(profile.contains("(allow file-write* (regex #\"^/dev/fd/[0-9]+$\"))"));
         assert!(profile.contains("(allow pseudo-tty)"));
     }
 

--- a/src/sandbox/seatbelt.rs
+++ b/src/sandbox/seatbelt.rs
@@ -106,6 +106,12 @@ pub struct SandboxParams {
     pub raw_rules: Option<String>,
     /// Allow execution of setuid/setgid binaries
     pub allow_exec_sugid: ExecSugid,
+    /// Environment variables to pass through (glob patterns supported)
+    pub pass_env: Vec<String>,
+    /// Environment variables to deny (glob patterns, takes precedence over pass_env)
+    pub deny_env: Vec<String>,
+    /// Environment variables to explicitly set
+    pub set_env: std::collections::HashMap<String, String>,
 }
 
 /// Generate a Seatbelt profile from the given parameters
@@ -129,14 +135,10 @@ pub fn generate_seatbelt_profile(params: &SandboxParams) -> Result<String, Seatb
     profile.push_str("; Process operations\n");
     profile.push_str("(allow process-fork)\n");
     profile.push_str("(allow process-exec)\n");
-    profile.push_str("(allow signal)\n");
+    profile.push_str("(allow signal (target self))\n");
 
     // Setuid/setgid execution rules
     match &params.allow_exec_sugid {
-        ExecSugid::Allow(true) => {
-            profile.push_str("; Setuid/setgid execution (allow all)\n");
-            profile.push_str("(allow process-exec* (with no-sandbox))\n");
-        }
         ExecSugid::Paths(paths) if !paths.is_empty() => {
             profile.push_str("; Setuid/setgid execution (specific binaries)\n");
             for path in paths {
@@ -158,9 +160,11 @@ pub fn generate_seatbelt_profile(params: &SandboxParams) -> Result<String, Seatb
     profile.push_str("(allow file-ioctl)\n");
     profile.push_str("(allow user-preference-read)\n\n");
 
-    // Mach services required for system functionality
+    // Mach services - restricted to lookup and task-name only
+    // Blocks mach-register (service impersonation) and mach-priv-* (privilege escalation)
     profile.push_str("; Mach services\n");
-    profile.push_str("(allow mach*)\n\n");
+    profile.push_str("(allow mach-lookup)\n");
+    profile.push_str("(allow mach-task-name)\n\n");
 
     // IPC for Unix sockets (needed for DNS resolution via mDNSResponder)
     profile.push_str("; IPC (Unix sockets)\n");
@@ -247,10 +251,23 @@ pub fn generate_seatbelt_profile(params: &SandboxParams) -> Result<String, Seatb
         profile.push('\n');
     }
 
-    // Device access (stdout, stderr, tty)
+    // Device access - restricted to specific devices needed for shell/terminal operation
     profile.push_str("; Device access\n");
-    profile.push_str("(allow file-write* (subpath \"/dev\"))\n");
-    profile.push_str("(allow file-read* (subpath \"/dev\"))\n");
+    profile.push_str("(allow file-read* (literal \"/dev/null\"))\n");
+    profile.push_str("(allow file-read* (literal \"/dev/zero\"))\n");
+    profile.push_str("(allow file-read* (literal \"/dev/random\"))\n");
+    profile.push_str("(allow file-read* (literal \"/dev/urandom\"))\n");
+    profile.push_str("(allow file-read* (literal \"/dev/tty\"))\n");
+    profile.push_str("(allow file-read* (literal \"/dev/ptmx\"))\n");
+    profile.push_str("(allow file-read* (regex #\"^/dev/ttys[0-9]+$\"))\n");
+    profile.push_str("(allow file-read* (literal \"/dev/dtracehelper\"))\n");
+    profile.push_str("(allow file-read* (literal \"/dev/autofs_nowait\"))\n");
+    profile.push_str("(allow file-write* (literal \"/dev/null\"))\n");
+    profile.push_str("(allow file-write* (literal \"/dev/zero\"))\n");
+    profile.push_str("(allow file-write* (literal \"/dev/tty\"))\n");
+    profile.push_str("(allow file-write* (literal \"/dev/ptmx\"))\n");
+    profile.push_str("(allow file-write* (regex #\"^/dev/ttys[0-9]+$\"))\n");
+    profile.push_str("(allow file-write* (literal \"/dev/dtracehelper\"))\n");
     // Pseudo-tty is required for interactive terminal features (backspace, arrow keys, etc.)
     profile.push_str("(allow pseudo-tty)\n\n");
 
@@ -543,6 +560,56 @@ mod tests {
     }
 
     #[test]
+    fn test_mach_restricted() {
+        let params = SandboxParams::default();
+        let profile = generate_seatbelt_profile(&params).unwrap();
+        assert!(
+            !profile.contains("(allow mach*)"),
+            "Should not allow unrestricted Mach IPC"
+        );
+        assert!(
+            profile.contains("(allow mach-lookup)"),
+            "Should allow Mach service lookups"
+        );
+        assert!(
+            profile.contains("(allow mach-task-name)"),
+            "Should allow Mach task name"
+        );
+    }
+
+    #[test]
+    fn test_signal_restricted_to_self() {
+        let params = SandboxParams::default();
+        let profile = generate_seatbelt_profile(&params).unwrap();
+        assert!(
+            profile.contains("(allow signal (target self))"),
+            "Signal should be restricted to self"
+        );
+        assert!(
+            !profile.contains("(allow signal)\n"),
+            "Unrestricted signal should not be present"
+        );
+    }
+
+    #[test]
+    fn test_dev_access_restricted() {
+        let params = SandboxParams::default();
+        let profile = generate_seatbelt_profile(&params).unwrap();
+        assert!(
+            !profile.contains("(allow file-write* (subpath \"/dev\"))"),
+            "Should not allow writes to all of /dev"
+        );
+        assert!(
+            !profile.contains("(allow file-read* (subpath \"/dev\"))"),
+            "Should not allow reads from all of /dev"
+        );
+        assert!(profile.contains("(allow file-write* (literal \"/dev/null\"))"));
+        assert!(profile.contains("(allow file-write* (literal \"/dev/tty\"))"));
+        assert!(profile.contains("(allow file-read* (literal \"/dev/urandom\"))"));
+        assert!(profile.contains("(allow pseudo-tty)"));
+    }
+
+    #[test]
     fn test_network_offline() {
         let params = SandboxParams {
             network_mode: NetworkMode::Offline,
@@ -661,17 +728,18 @@ mod tests {
     }
 
     #[test]
-    fn test_exec_sugid_allow_all() {
+    fn test_exec_sugid_true_is_safe() {
+        // Even if someone has allow_exec_sugid = true in old config, it must NOT produce no-sandbox rule
         let params = SandboxParams {
-            allow_exec_sugid: ExecSugid::Allow(true),
+            allow_exec_sugid: ExecSugid::Deny(true),
             ..Default::default()
         };
         let profile = generate_seatbelt_profile(&params).unwrap();
         assert!(
-            profile.contains("(allow process-exec* (with no-sandbox))"),
-            "Allow(true) should emit global sugid allow, got:\n{}",
-            profile
+            !profile.contains("(allow process-exec* (with no-sandbox))"),
+            "Deny(true) must NOT emit global sugid allow"
         );
+        assert!(profile.contains("; Setuid/setgid execution denied (default)"));
     }
 
     #[test]

--- a/src/sandbox/seatbelt.rs
+++ b/src/sandbox/seatbelt.rs
@@ -262,12 +262,17 @@ pub fn generate_seatbelt_profile(params: &SandboxParams) -> Result<String, Seatb
     profile.push_str("(allow file-read* (regex #\"^/dev/ttys[0-9]+$\"))\n");
     profile.push_str("(allow file-read* (literal \"/dev/dtracehelper\"))\n");
     profile.push_str("(allow file-read* (literal \"/dev/autofs_nowait\"))\n");
+    profile.push_str("(allow file-read* (literal \"/dev/stdin\"))\n");
+    profile.push_str("(allow file-read* (literal \"/dev/stdout\"))\n");
+    profile.push_str("(allow file-read* (literal \"/dev/stderr\"))\n");
     profile.push_str("(allow file-write* (literal \"/dev/null\"))\n");
     profile.push_str("(allow file-write* (literal \"/dev/zero\"))\n");
     profile.push_str("(allow file-write* (literal \"/dev/tty\"))\n");
     profile.push_str("(allow file-write* (literal \"/dev/ptmx\"))\n");
     profile.push_str("(allow file-write* (regex #\"^/dev/ttys[0-9]+$\"))\n");
     profile.push_str("(allow file-write* (literal \"/dev/dtracehelper\"))\n");
+    profile.push_str("(allow file-write* (literal \"/dev/stdout\"))\n");
+    profile.push_str("(allow file-write* (literal \"/dev/stderr\"))\n");
     // Pseudo-tty is required for interactive terminal features (backspace, arrow keys, etc.)
     profile.push_str("(allow pseudo-tty)\n\n");
 
@@ -606,6 +611,11 @@ mod tests {
         assert!(profile.contains("(allow file-write* (literal \"/dev/null\"))"));
         assert!(profile.contains("(allow file-write* (literal \"/dev/tty\"))"));
         assert!(profile.contains("(allow file-read* (literal \"/dev/urandom\"))"));
+        assert!(profile.contains("(allow file-read* (literal \"/dev/stdin\"))"));
+        assert!(profile.contains("(allow file-read* (literal \"/dev/stdout\"))"));
+        assert!(profile.contains("(allow file-read* (literal \"/dev/stderr\"))"));
+        assert!(profile.contains("(allow file-write* (literal \"/dev/stdout\"))"));
+        assert!(profile.contains("(allow file-write* (literal \"/dev/stderr\"))"));
         assert!(profile.contains("(allow pseudo-tty)"));
     }
 

--- a/src/utils/paths.rs
+++ b/src/utils/paths.rs
@@ -1,17 +1,34 @@
-use std::path::PathBuf;
+use std::path::{Component, Path, PathBuf};
 
-/// Expand a path string, handling ~ for home directory
+/// Expand a path string, handling ~ for home directory and resolving symlinks.
+///
+/// After tilde/env expansion, resolves symlinks in the longest existing prefix
+/// of the path. This is critical on macOS where `/tmp` → `/private/tmp`, and
+/// Seatbelt operates on resolved paths.
+///
+/// For glob paths like `/tmp/playwright*`, only the non-glob prefix (`/tmp/`)
+/// is resolved, preserving the glob suffix.
 pub fn expand_path(path: &str) -> PathBuf {
-    if let Some(stripped) = path.strip_prefix("~/") {
+    let expanded = if let Some(stripped) = path.strip_prefix("~/") {
         if let Some(home) = dirs::home_dir() {
-            return home.join(stripped);
+            home.join(stripped)
+        } else {
+            shell_expand(path)
         }
     } else if path == "~" {
         if let Some(home) = dirs::home_dir() {
-            return home;
+            home
+        } else {
+            shell_expand(path)
         }
-    }
+    } else {
+        shell_expand(path)
+    };
 
+    resolve_symlinks(&expanded)
+}
+
+fn shell_expand(path: &str) -> PathBuf {
     PathBuf::from(
         shellexpand::full(path)
             .unwrap_or_else(|_| path.into())
@@ -19,7 +36,148 @@ pub fn expand_path(path: &str) -> PathBuf {
     )
 }
 
+/// Resolve symlinks in the longest existing prefix of a path.
+///
+/// Walks the path components to find where glob characters start (or the full
+/// path if no globs). Then finds the longest existing ancestor and canonicalizes
+/// it, appending any remaining unresolved components.
+///
+/// Example: `/tmp/playwright*` → `/private/tmp/playwright*` (macOS)
+fn resolve_symlinks(path: &Path) -> PathBuf {
+    let path_str = path.to_string_lossy();
+
+    // Find the first component index that contains a glob character
+    let components: Vec<Component> = path.components().collect();
+    let glob_start = components
+        .iter()
+        .position(|c| {
+            let s = c.as_os_str().to_string_lossy();
+            s.contains('*') || s.contains('?')
+        })
+        .unwrap_or(components.len());
+
+    // Build the prefix (everything before the glob) to resolve
+    let prefix: PathBuf = components[..glob_start].iter().collect();
+
+    // Build the suffix (glob and beyond) to preserve as-is
+    let suffix: PathBuf = if glob_start < components.len() {
+        components[glob_start..].iter().collect()
+    } else {
+        PathBuf::new()
+    };
+
+    // Walk up the prefix to find the longest existing ancestor we can canonicalize
+    let (resolved_base, unresolved_tail) = resolve_existing_prefix(&prefix);
+
+    let mut result = resolved_base;
+    if !unresolved_tail.as_os_str().is_empty() {
+        result.push(unresolved_tail);
+    }
+    if !suffix.as_os_str().is_empty() {
+        result.push(suffix);
+    }
+
+    // Only return the resolved path if it's still logically the same path
+    // (just with symlinks resolved). If canonicalize changed nothing meaningful, return as-is.
+    if result.to_string_lossy() == path_str {
+        path.to_path_buf()
+    } else {
+        result
+    }
+}
+
+/// Walk up the path to find the longest existing prefix, canonicalize it,
+/// and return (resolved_prefix, remaining_tail).
+fn resolve_existing_prefix(path: &Path) -> (PathBuf, PathBuf) {
+    let mut current = path.to_path_buf();
+    let mut tail_components: Vec<std::ffi::OsString> = Vec::new();
+
+    loop {
+        if let Ok(resolved) = std::fs::canonicalize(&current) {
+            let tail: PathBuf = tail_components.iter().rev().collect();
+            return (resolved, tail);
+        }
+
+        match current.parent() {
+            Some(parent) if !parent.as_os_str().is_empty() => {
+                if let Some(file_name) = current.file_name() {
+                    tail_components.push(file_name.to_os_string());
+                }
+                current = parent.to_path_buf();
+            }
+            _ => {
+                // Nothing could be resolved, return the original path
+                return (path.to_path_buf(), PathBuf::new());
+            }
+        }
+    }
+}
+
 /// Expand all paths in a vector
 pub fn expand_paths(paths: &[String]) -> Vec<PathBuf> {
     paths.iter().map(|p| expand_path(p)).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_tmp_symlink_resolved() {
+        // On macOS, /tmp is a symlink to /private/tmp
+        if std::fs::read_link("/tmp").is_ok() {
+            let result = expand_path("/tmp/playwright*");
+            assert!(
+                result.to_string_lossy().starts_with("/private/tmp/"),
+                "Expected /private/tmp/ prefix, got: {}",
+                result.display()
+            );
+            assert!(
+                result.to_string_lossy().ends_with("playwright*"),
+                "Glob suffix should be preserved, got: {}",
+                result.display()
+            );
+        }
+    }
+
+    #[test]
+    fn test_tmp_non_glob_resolved() {
+        if std::fs::read_link("/tmp").is_ok() {
+            let result = expand_path("/tmp/somedir");
+            assert!(
+                result.to_string_lossy().starts_with("/private/tmp/"),
+                "Expected /private/tmp/ prefix, got: {}",
+                result.display()
+            );
+        }
+    }
+
+    #[test]
+    fn test_tilde_expansion_preserved() {
+        let result = expand_path("~/test");
+        assert!(
+            !result.to_string_lossy().starts_with("~"),
+            "Tilde should be expanded, got: {}",
+            result.display()
+        );
+    }
+
+    #[test]
+    fn test_non_symlink_path_unchanged() {
+        let result = expand_path("/usr/bin");
+        assert_eq!(result, PathBuf::from("/usr/bin"));
+    }
+
+    #[test]
+    fn test_glob_in_middle_preserved() {
+        if std::fs::read_link("/tmp").is_ok() {
+            let result = expand_path("/tmp/convex*");
+            assert_eq!(
+                result,
+                PathBuf::from("/private/tmp/convex*"),
+                "Got: {}",
+                result.display()
+            );
+        }
+    }
 }

--- a/tests/config_test.rs
+++ b/tests/config_test.rs
@@ -519,20 +519,20 @@ allow_exec_sugid = ["/bin/ps"]
 fn test_merge_exec_sugid_project_overrides_global() {
     let global = Config {
         sandbox: SandboxConfig {
-            allow_exec_sugid: ExecSugid::Allow(false),
+            allow_exec_sugid: ExecSugid::Deny(false),
             ..Default::default()
         },
         ..Default::default()
     };
     let project = Config {
         sandbox: SandboxConfig {
-            allow_exec_sugid: ExecSugid::Allow(true),
+            allow_exec_sugid: ExecSugid::Deny(true),
             ..Default::default()
         },
         ..Default::default()
     };
     let merged = merge_configs(&global, &project);
-    assert_eq!(merged.sandbox.allow_exec_sugid, ExecSugid::Allow(true));
+    assert_eq!(merged.sandbox.allow_exec_sugid, ExecSugid::Deny(true));
 }
 
 #[test]
@@ -562,7 +562,7 @@ fn test_merge_exec_sugid_paths_union() {
 }
 
 #[test]
-fn test_merge_exec_sugid_paths_override_by_bool() {
+fn test_merge_exec_sugid_paths_override_by_deny() {
     let global = Config {
         sandbox: SandboxConfig {
             allow_exec_sugid: ExecSugid::Paths(vec!["/bin/ps".into()]),
@@ -572,13 +572,13 @@ fn test_merge_exec_sugid_paths_override_by_bool() {
     };
     let project = Config {
         sandbox: SandboxConfig {
-            allow_exec_sugid: ExecSugid::Allow(true),
+            allow_exec_sugid: ExecSugid::Deny(true),
             ..Default::default()
         },
         ..Default::default()
     };
     let merged = merge_configs(&global, &project);
-    assert_eq!(merged.sandbox.allow_exec_sugid, ExecSugid::Allow(true));
+    assert_eq!(merged.sandbox.allow_exec_sugid, ExecSugid::Deny(true));
 }
 
 #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -242,6 +242,62 @@ fn test_sandbox_temp_file_creation() {
     assert_eq!(String::from_utf8_lossy(&stdout).trim(), "temp data");
 }
 
+#[test]
+fn test_zsh_process_substitution_works() {
+    skip_if_no_sandbox!();
+
+    let temp = TempDir::new().unwrap();
+    let params = fs_sandbox_params(temp.path().to_path_buf());
+
+    let (status, stdout, stderr) = execute_sandboxed_captured(
+        &params,
+        &[
+            "/bin/zsh".to_string(),
+            "-c".to_string(),
+            "source <(printf 'echo zsh-process-substitution-ok\\n')".to_string(),
+        ],
+    )
+    .unwrap();
+
+    assert!(
+        status.success(),
+        "zsh process substitution should work: {}",
+        String::from_utf8_lossy(&stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&stdout).trim(),
+        "zsh-process-substitution-ok"
+    );
+}
+
+#[test]
+fn test_bash_process_substitution_works() {
+    skip_if_no_sandbox!();
+
+    let temp = TempDir::new().unwrap();
+    let params = fs_sandbox_params(temp.path().to_path_buf());
+
+    let (status, stdout, stderr) = execute_sandboxed_captured(
+        &params,
+        &[
+            "/bin/bash".to_string(),
+            "-c".to_string(),
+            "source <(printf 'echo bash-process-substitution-ok\\n')".to_string(),
+        ],
+    )
+    .unwrap();
+
+    assert!(
+        status.success(),
+        "bash process substitution should work: {}",
+        String::from_utf8_lossy(&stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&stdout).trim(),
+        "bash-process-substitution-ok"
+    );
+}
+
 // ============================================================================
 // Network Integration Tests
 // ============================================================================

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -84,6 +84,9 @@ fn fs_sandbox_params(working_dir: PathBuf) -> SandboxParams {
         allow_list_dirs: vec![],
         raw_rules: None,
         allow_exec_sugid: Default::default(),
+        pass_env: vec![],
+        deny_env: vec![],
+        set_env: Default::default(),
     }
 }
 
@@ -261,6 +264,9 @@ fn network_sandbox_params(working_dir: PathBuf, mode: NetworkMode) -> SandboxPar
         allow_list_dirs: vec![],
         raw_rules: None,
         allow_exec_sugid: Default::default(),
+        pass_env: vec![],
+        deny_env: vec![],
+        set_env: Default::default(),
     }
 }
 
@@ -706,17 +712,11 @@ allow_write = ["/custom/write"]
 }
 
 #[test]
-fn test_load_missing_profile_falls_back_to_online() {
+fn test_load_missing_profile_skipped_fail_closed() {
     let profiles = load_profiles(&["nonexistent".to_string()], None);
-    assert_eq!(
-        profiles.len(),
-        1,
-        "Should return one profile (online fallback) for missing profile"
-    );
-    // Verify it's the online profile (has network_mode = Some(Online))
-    assert_eq!(
-        profiles[0].network_mode,
-        Some(sx::config::schema::NetworkMode::Online)
+    assert!(
+        profiles.is_empty(),
+        "Unknown profile should be skipped (fail-closed, no fallback)"
     );
 }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -11,7 +11,8 @@ use std::process::Command;
 use sx::config::global::load_global_config;
 use sx::config::merge::merge_configs;
 use sx::config::profile::{
-    compose_profiles, load_profiles, BuiltinProfile, Profile, ProfileFilesystem, ProfileShell,
+    compose_profiles, load_profiles, BuiltinProfile, Profile, ProfileError, ProfileFilesystem,
+    ProfileShell,
 };
 use sx::config::project::load_project_config;
 use sx::config::project::PROJECT_CONFIG_NAME;
@@ -605,7 +606,7 @@ fn test_load_all_builtin_profiles() {
     let builtin_names = ["base", "online", "localhost", "rust", "claude", "gpg"];
 
     for name in builtin_names {
-        let profiles = load_profiles(&[name.to_string()], None);
+        let profiles = load_profiles(&[name.to_string()], None).unwrap();
         assert_eq!(profiles.len(), 1, "Should load builtin profile: {}", name);
     }
 }
@@ -756,7 +757,7 @@ allow_write = ["/custom/write"]
     )
     .unwrap();
 
-    let profiles = load_profiles(&["custom".to_string()], Some(temp.path()));
+    let profiles = load_profiles(&["custom".to_string()], Some(temp.path())).unwrap();
     assert_eq!(profiles.len(), 1, "Should load custom profile");
 
     let profile = &profiles[0];
@@ -768,11 +769,11 @@ allow_write = ["/custom/write"]
 }
 
 #[test]
-fn test_load_missing_profile_skipped_fail_closed() {
-    let profiles = load_profiles(&["nonexistent".to_string()], None);
+fn test_load_missing_profile_returns_error() {
+    let result = load_profiles(&["nonexistent".to_string()], None);
     assert!(
-        profiles.is_empty(),
-        "Unknown profile should be skipped (fail-closed, no fallback)"
+        matches!(result, Err(ProfileError::NotFound { .. })),
+        "Unknown profile should return NotFound error"
     );
 }
 

--- a/tests/profile_test.rs
+++ b/tests/profile_test.rs
@@ -268,15 +268,15 @@ fn test_builtin_profile_opencode() {
 #[test]
 fn test_compose_profiles_exec_sugid_last_bool_wins() {
     let p1 = Profile {
-        allow_exec_sugid: Some(ExecSugid::Allow(true)),
+        allow_exec_sugid: Some(ExecSugid::Deny(true)),
         ..Default::default()
     };
     let p2 = Profile {
-        allow_exec_sugid: Some(ExecSugid::Allow(false)),
+        allow_exec_sugid: Some(ExecSugid::Deny(false)),
         ..Default::default()
     };
     let composed = compose_profiles(&[p1, p2]);
-    assert_eq!(composed.allow_exec_sugid, Some(ExecSugid::Allow(false)));
+    assert_eq!(composed.allow_exec_sugid, Some(ExecSugid::Deny(false)));
 }
 
 #[test]
@@ -317,17 +317,17 @@ fn test_compose_profiles_exec_sugid_none_inherits() {
 }
 
 #[test]
-fn test_compose_profiles_exec_sugid_bool_overrides_paths() {
+fn test_compose_profiles_exec_sugid_deny_overrides_paths() {
     let p1 = Profile {
         allow_exec_sugid: Some(ExecSugid::Paths(vec!["/bin/ps".into()])),
         ..Default::default()
     };
     let p2 = Profile {
-        allow_exec_sugid: Some(ExecSugid::Allow(true)),
+        allow_exec_sugid: Some(ExecSugid::Deny(false)),
         ..Default::default()
     };
     let composed = compose_profiles(&[p1, p2]);
-    assert_eq!(composed.allow_exec_sugid, Some(ExecSugid::Allow(true)));
+    assert_eq!(composed.allow_exec_sugid, Some(ExecSugid::Deny(false)));
 }
 
 // === Seatbelt Profile Compose Tests ===

--- a/tests/profile_test.rs
+++ b/tests/profile_test.rs
@@ -112,7 +112,7 @@ fn test_load_profile_not_found() {
 
 #[test]
 fn test_load_profiles_by_name() {
-    let profiles = load_profiles(&["base".to_string(), "online".to_string()], None);
+    let profiles = load_profiles(&["base".to_string(), "online".to_string()], None).unwrap();
     assert_eq!(profiles.len(), 2);
 }
 
@@ -130,7 +130,7 @@ allow_read = ["~/mypath"]
     )
     .unwrap();
 
-    let profiles = load_profiles(&["myprofile".to_string()], Some(temp_dir.path()));
+    let profiles = load_profiles(&["myprofile".to_string()], Some(temp_dir.path())).unwrap();
     assert_eq!(profiles.len(), 1);
     assert!(profiles[0]
         .filesystem

--- a/tests/seatbelt_test.rs
+++ b/tests/seatbelt_test.rs
@@ -223,6 +223,22 @@ fn test_base_profile_integration() {
         profile.contains(r#"(allow file-read* (subpath "/usr"))"#),
         "Base profile should allow /usr"
     );
+    assert!(
+        !profile.contains(r#"(allow file-read* (subpath "/dev"))"#),
+        "Base profile should not re-introduce broad /dev reads"
+    );
+    assert!(
+        profile.contains(r#"(allow file-read-data (literal "/dev"))"#),
+        "Base profile should allow directory-only access to /dev"
+    );
+    assert!(
+        profile.contains(r#"(allow file-read-data (literal "/dev/fd"))"#),
+        "Base profile should allow directory-only access to /dev/fd"
+    );
+    assert!(
+        profile.contains(r#"(allow file-read* (literal "/dev/null"))"#),
+        "Base profile should keep the explicit device allowlist"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Prevent DYLD injection and credential leakage by filtering environment variables passed to sandboxed processes, with glob-pattern `pass_env`/`deny_env` support and deny-wins semantics
- Close privilege escalation paths: restrict Mach IPC to `mach-lookup`/`mach-task-name` (blocks `mach-register` and `mach-priv-*`), restrict `signal` to `(target self)`, replace broad `/dev` subpath access with an explicit device allowlist
- Remove the `ExecSugid::Allow(true)` no-sandbox escape hatch entirely — old configs with `allow_exec_sugid = true` now silently degrade to deny (safe); unknown profiles fail-closed instead of falling back to the online profile

## Test plan
- [x] `cargo test` passes (233 tests, 0 failures)
- [x] `sx run -- env` shows only expected vars with a profile that sets `pass_env`
- [x] `sx run -- env | grep DYLD` returns empty (DYLD vars never leak)
- [x] Interactive shell session works normally (backspace, arrow keys, terminal resize)
- [x] `sx --profile nonexistent -- echo hi` prints error and exits, does not silently run under online profile
- [x] `curl` and Python DNS resolution still work under `online` profile