### PR TITLE
feat(executor): forward signals to sandboxed process group to prevent orphans

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -529,6 +529,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a0c28ca5908dbdbcd52e6fdaa00358ab88637f8ab33e1f188dd510eb44b53d"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -548,9 +568,11 @@ dependencies = [
  "assert_cmd",
  "clap",
  "dirs",
+ "libc",
  "predicates",
  "serde",
  "shellexpand",
+ "signal-hook",
  "tempfile",
  "thiserror",
  "toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,10 @@ thiserror = "2"
 anyhow = "1"
 tempfile = "3"
 
+# Signal handling and syscalls
+signal-hook = "0.4"
+libc = "0.2"
+
 [dev-dependencies]
 assert_cmd = "2"
 predicates = "3"

--- a/src/sandbox/executor.rs
+++ b/src/sandbox/executor.rs
@@ -1,11 +1,21 @@
 // sandbox-exec invocation
 use crate::sandbox::seatbelt::{generate_seatbelt_profile, SandboxParams, SeatbeltError};
 use crate::sandbox::trace::TraceSession;
+use signal_hook::consts::{SIGHUP, SIGINT, SIGTERM};
+use signal_hook::iterator::Signals;
 use std::fs;
 use std::io;
+use std::os::unix::process::CommandExt;
 use std::path::Path;
 use std::process::{Command, ExitStatus, Stdio};
+use std::time::Duration;
 use tempfile::{NamedTempFile, TempDir};
+
+/// Grace period between SIGTERM and SIGKILL when forwarding shutdown signals
+/// to the sandboxed process group. Long enough for typical cleanup (closing
+/// IPC peers, flushing buffers) but short enough that orphaned processes do
+/// not linger after `sx` is signalled.
+const SIGTERM_TO_SIGKILL_GRACE: Duration = Duration::from_secs(2);
 
 /// Exit codes for sandbox execution
 pub mod exit_codes {
@@ -171,8 +181,11 @@ SAVEHIST=0
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit());
 
-    // Execute and wait
-    let status = cmd.spawn()?.wait()?;
+    // Execute and wait, forwarding shutdown signals to the entire sandboxed subtree.
+    // Without this, sx exits without signalling its sandboxed descendants — IPC
+    // children (e.g. Node `--useNodeIpc` workers) get reparented to launchd and
+    // accumulate forever.
+    let status = spawn_with_signal_forwarding(cmd)?;
 
     // Stop trace session
     if let Some(ref mut session) = trace_session {
@@ -215,6 +228,74 @@ pub fn execute_sandboxed_captured(
 /// Print the generated seatbelt profile (dry-run mode)
 pub fn dry_run(params: &SandboxParams) -> Result<String, SeatbeltError> {
     generate_seatbelt_profile(params)
+}
+
+/// RAII guard that SIGKILLs an entire process group on drop.
+/// Provides panic / early-return safety so the sandbox subtree is never
+/// orphaned if `sx` exits along an unexpected path.
+struct PgidKillGuard {
+    pgid: Option<i32>,
+}
+
+impl PgidKillGuard {
+    fn new(pgid: i32) -> Self {
+        Self { pgid: Some(pgid) }
+    }
+
+    /// Disarm the guard after a clean exit so we do not signal a dead pgid.
+    fn disarm(&mut self) {
+        self.pgid = None;
+    }
+}
+
+impl Drop for PgidKillGuard {
+    fn drop(&mut self) {
+        if let Some(pgid) = self.pgid {
+            // Best-effort: ignore errors (group may already be gone).
+            unsafe {
+                libc::kill(-pgid, libc::SIGKILL);
+            }
+        }
+    }
+}
+
+/// Send `sig` to the entire process group identified by `pgid`.
+fn signal_pgroup(pgid: i32, sig: libc::c_int) {
+    unsafe {
+        libc::kill(-pgid, sig);
+    }
+}
+
+/// Spawn `cmd` in its own process group and wait for it, forwarding
+/// SIGINT/SIGTERM/SIGHUP to the sandboxed subtree with a SIGTERM →
+/// grace-period → SIGKILL escalation.
+fn spawn_with_signal_forwarding(mut cmd: Command) -> io::Result<ExitStatus> {
+    // Put the child in its own process group so kill(-pgid, ...) reaches every
+    // descendant in one syscall and does not loop back to sx itself.
+    cmd.process_group(0);
+
+    let mut child = cmd.spawn()?;
+    let pgid = child.id() as i32;
+    let mut kill_guard = PgidKillGuard::new(pgid);
+
+    let mut signals = Signals::new([SIGINT, SIGTERM, SIGHUP])?;
+    let signal_handle = signals.handle();
+
+    let signal_thread = std::thread::spawn(move || {
+        if signals.forever().next().is_some() {
+            signal_pgroup(pgid, libc::SIGTERM);
+            std::thread::sleep(SIGTERM_TO_SIGKILL_GRACE);
+            signal_pgroup(pgid, libc::SIGKILL);
+        }
+    });
+
+    let status = child.wait()?;
+
+    kill_guard.disarm();
+    signal_handle.close();
+    let _ = signal_thread.join();
+
+    Ok(status)
 }
 
 /// Check if an environment variable name matches any glob-like pattern.
@@ -362,5 +443,42 @@ mod tests {
             "DYLD_INSERT_LIBRARIES",
             &["DYLD_*".to_string()]
         ));
+    }
+
+    /// Verifies the foundational mechanism for issue #37: spawning a child via
+    /// `Command::process_group(0)` isolates it into its own process group so we
+    /// can deliver group-wide signals via `kill(-pgid, ...)`. This is a direct
+    /// unit test of the kernel behavior `spawn_with_signal_forwarding` relies
+    /// on; it does not require `sandbox-exec` and runs in any environment.
+    #[test]
+    fn test_process_group_isolation_for_signal_forwarding() {
+        let mut cmd = Command::new("/bin/sh");
+        cmd.args(["-c", "sleep 5"])
+            .process_group(0)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+
+        let mut child = cmd.spawn().expect("spawn /bin/sh");
+        let child_pid = child.id() as i32;
+
+        let child_pgid = unsafe { libc::getpgid(child_pid) };
+        assert_eq!(
+            child_pgid, child_pid,
+            "child should lead its own process group (pgid == pid)"
+        );
+
+        let test_pgid = unsafe { libc::getpgid(0) };
+        assert_ne!(
+            test_pgid, child_pgid,
+            "child pgid must be isolated from test process pgid"
+        );
+
+        // Cleanup: signal the entire group, mirroring what the production
+        // signal handler does, then reap the child.
+        unsafe {
+            libc::kill(-child_pid, libc::SIGTERM);
+        }
+        let _ = child.wait();
     }
 }

--- a/tests/signal_test.rs
+++ b/tests/signal_test.rs
@@ -1,0 +1,203 @@
+//! Integration tests for signal forwarding (issue #37).
+//!
+//! Verifies that `sx` forwards SIGINT/SIGTERM/SIGHUP to the entire sandboxed
+//! process subtree so descendants are not orphaned to launchd when `sx` exits.
+
+use std::fs;
+use std::process::{Command, Stdio};
+use std::thread;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+/// Path to the `sx` binary produced by Cargo for this test target.
+const SX_BIN: &str = env!("CARGO_BIN_EXE_sx");
+
+/// Probe whether `sandbox-exec` accepts a custom deny-default profile on this
+/// system. On hardened macOS configurations custom profiles can be blocked,
+/// in which case there is nothing meaningful to assert about signal forwarding.
+fn is_custom_sandbox_available() -> bool {
+    let probe = r#"(version 1)
+(deny default)
+(allow process-fork)
+(allow process-exec)
+(allow signal (target self))
+(allow sysctl-read)
+(allow file-read-metadata)
+(allow mach-lookup)
+(allow file-read* (subpath "/usr"))
+(allow file-read* (subpath "/bin"))
+"#;
+    let Ok(temp) = tempfile::NamedTempFile::new() else {
+        return false;
+    };
+    if fs::write(temp.path(), probe).is_err() {
+        return false;
+    }
+    Command::new("/usr/bin/sandbox-exec")
+        .arg("-f")
+        .arg(temp.path())
+        .arg("/bin/echo")
+        .arg("ok")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+macro_rules! skip_if_no_sandbox {
+    () => {
+        if !is_custom_sandbox_available() {
+            eprintln!("Skipping test: sandbox-exec custom profiles unavailable");
+            return;
+        }
+    };
+}
+
+/// Generate a sleep duration unlikely to collide with anything else on the
+/// system, so we can identify our descendants in `ps` output. ~115 days is
+/// clearly synthetic and highly unlikely to match an unrelated process.
+fn unique_marker() -> u64 {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos() as u64)
+        .unwrap_or(0);
+    9_000_000 + nanos % 1_000_000
+}
+
+/// Count running processes whose `ps -axo command` line contains `pattern`,
+/// excluding the `ps` invocation itself.
+fn count_processes(pattern: &str) -> usize {
+    let output = Command::new("/bin/ps")
+        .args(["-axo", "command"])
+        .output()
+        .expect("invoke ps");
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter(|line| line.contains(pattern) && !line.contains("/bin/ps"))
+        .count()
+}
+
+/// Best-effort: SIGKILL every process whose command line contains `pattern`.
+/// Used as test cleanup to avoid leaking orphans across test runs.
+fn pkill_pattern(pattern: &str) {
+    let Ok(output) = Command::new("/bin/ps")
+        .args(["-axo", "pid,command"])
+        .output()
+    else {
+        return;
+    };
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for line in stdout.lines() {
+        if !line.contains(pattern) || line.contains("/bin/ps") {
+            continue;
+        }
+        let Some(pid_str) = line.split_whitespace().next() else {
+            continue;
+        };
+        if let Ok(pid) = pid_str.parse::<i32>() {
+            unsafe {
+                libc::kill(pid, libc::SIGKILL);
+            }
+        }
+    }
+}
+
+#[test]
+fn test_sigterm_to_sx_propagates_to_sandbox_subtree() {
+    skip_if_no_sandbox!();
+
+    let marker = unique_marker();
+    let pattern = format!("sleep {}", marker);
+    let shell_cmd = format!("/bin/sleep {} & /bin/sleep {} & wait", marker, marker);
+
+    let mut child = Command::new(SX_BIN)
+        .arg("--no-config")
+        .arg("--")
+        .arg("/bin/sh")
+        .arg("-c")
+        .arg(&shell_cmd)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn sx");
+    let sx_pid = child.id();
+
+    // Give sandbox-exec → sh → sleep chain time to come up.
+    thread::sleep(Duration::from_millis(800));
+    let before = count_processes(&pattern);
+    assert!(
+        before >= 2,
+        "expected at least 2 sleep descendants before SIGTERM, saw {}",
+        before
+    );
+
+    unsafe {
+        libc::kill(sx_pid as i32, libc::SIGTERM);
+    }
+
+    // Issue #37 acceptance criterion: zero descendants remain after 2s.
+    // The 3s total budget covers SIGTERM → grace → SIGKILL plus reaping.
+    thread::sleep(Duration::from_secs(3));
+    let after = count_processes(&pattern);
+
+    // Always reap and cleanup before asserting so a failure does not leak processes.
+    let _ = child.wait();
+    if after != 0 {
+        pkill_pattern(&pattern);
+    }
+
+    assert_eq!(
+        after, 0,
+        "expected sandbox subtree to be gone 3s after SIGTERM, {} stragglers remain",
+        after
+    );
+}
+
+#[test]
+fn test_sigkill_to_sx_orphans_subtree_known_limitation() {
+    skip_if_no_sandbox!();
+
+    // SIGKILL is uncatchable; sx has no opportunity to forward it. This test
+    // pins down the limitation: `kill_on_drop` / signal handlers do not help
+    // when sx itself is force-killed. A future supervisor process could fix
+    // this — when it lands, this test will start failing and should be updated.
+    let marker = unique_marker();
+    let pattern = format!("sleep {}", marker);
+    let shell_cmd = format!("/bin/sleep {}", marker);
+
+    let mut child = Command::new(SX_BIN)
+        .arg("--no-config")
+        .arg("--")
+        .arg("/bin/sh")
+        .arg("-c")
+        .arg(&shell_cmd)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn sx");
+    let sx_pid = child.id();
+
+    thread::sleep(Duration::from_millis(800));
+    let before = count_processes(&pattern);
+    assert!(
+        before >= 1,
+        "expected sleep descendant to be running before SIGKILL, saw {}",
+        before
+    );
+
+    unsafe {
+        libc::kill(sx_pid as i32, libc::SIGKILL);
+    }
+    let _ = child.wait();
+
+    // Brief settle; orphan is reparented to launchd but stays alive.
+    thread::sleep(Duration::from_millis(500));
+    let after_kill = count_processes(&pattern);
+
+    // Cleanup orphans before asserting, regardless of outcome.
+    pkill_pattern(&pattern);
+
+    assert!(
+        after_kill >= 1,
+        "expected SIGKILL to leave at least one orphan (uncatchable signal). \
+         If this fails, supervisor logic has improved — update this test."
+    );
+}


### PR DESCRIPTION
Closes #37

## Summary
- When `sx` receives SIGINT/SIGTERM/SIGHUP, descendant processes in the sandboxed subtree were left orphaned and reparented to launchd — accumulating silently over time (especially Node `--useNodeIpc` workers).
- Spawning the sandboxed child in its own process group (`process_group(0)`) and forwarding signals via `kill(-pgid, ...)` ensures the entire subtree is torn down with a SIGTERM → 2s grace → SIGKILL escalation.
- A `PgidKillGuard` RAII type provides panic-safe cleanup so the subtree is never orphaned even on unexpected exit paths.

## Test plan
- [x] `cargo test` passes — unit test verifies `process_group(0)` produces an isolated pgid
- [x] `cargo test --test signal_test` passes — integration test asserts zero descendants remain 3s after SIGTERM to `sx`
- [x] Manual test with scripts/test-signal-tsserver.sh