### PR TITLE
fix(ci): suppress false positive gitleaks finding in secrets-scan

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,1 @@
+4d9a296f953d1c15d1b58f0a83a0b42bc41cc7cf:.github/workflows/QA.yaml:generic-api-key:85


### PR DESCRIPTION
## Summary
- Gitleaks flags `cargo-deny-0.18` (a cache key in a historical QA workflow commit) as a `generic-api-key` due to entropy — it is not a real secret
- The offending commit (`4d9a296`) is reachable from `main` via tag history, so history rewriting is not viable; adding `.gitleaksignore` is the correct suppression mechanism
- Pins the exact fingerprint so only this one finding is ignored, leaving future real leaks detectable

## Test plan
- [x] Re-run the `Security Scan / secrets-scan` workflow manually via `workflow_dispatch` and confirm it passes